### PR TITLE
Windows világos téma bug javítva

### DIFF
--- a/UI/Controllers/CameraOptionsController.py
+++ b/UI/Controllers/CameraOptionsController.py
@@ -74,7 +74,7 @@ class CameraOptionsController(QWidget):
             self.timer.timeout.connect(self.updateFrame)
             self.timer.start(10)
             self.is_camera_on = True
-            self.ui.btnStartCam.setStyleSheet(options_button_active_style)
+            self.ui.btnStartCam.setStyleSheet(options_button_active_style + 'background-color: rgb(201, 97, 97)')
             self.ui.btnStartCam.setText('Kamera leállítása')
         else:
             self.timer.stop()
@@ -249,7 +249,8 @@ class CameraOptionsController(QWidget):
         return '''<html>
             <style>
                 p { line-height: 1.2;
-                    font-size: 12pt; }
+                    font-size: 12pt;
+                    color: white; }
             </style>
             <body>
                 <p align='justify'>'''+ text +'''</p>

--- a/UI/Controllers/OptionsMenuController.py
+++ b/UI/Controllers/OptionsMenuController.py
@@ -69,6 +69,10 @@ class OptionsMenuController(QWidget):
             btnKey.setIcon(QIcon('Resources\\Icons\\keyboard.png'))
             btnKey.setIconSize(QSize(60, 60))
 
+            #Windows világos téma miatt
+            btnCombo.setStyleSheet(noborder)
+            btnKey.setStyleSheet(noborder)
+            btnConsole.setStyleSheet(noborder)
 
             if(entry['highlight'] == 0):
                 btnCombo.setIcon(QIcon('Resources\\Icons\\widget_green.png'))

--- a/UI/Controllers/TrainMenuController.py
+++ b/UI/Controllers/TrainMenuController.py
@@ -69,7 +69,7 @@ class TrainMenuController(QWidget):
             if len(self.data) > 0:
                 for key, value in self.data.items():
                     entry = QPushButton(value['gesture'])
-                    entry.setStyleSheet(predefined_label_style)
+                    entry.setStyleSheet(predefined_label_style + noborder)
                     entry.setFont(self.font)
                     entry.setFixedHeight(33)
                     
@@ -82,12 +82,12 @@ class TrainMenuController(QWidget):
         for i in range(self.scroll_layout.count()):
             item = self.scroll_layout.itemAt(i).widget()
             if item != None:
-                item.setStyleSheet(predefined_label_style)
+                item.setStyleSheet(predefined_label_style + noborder)
         if self.selected_gesture != key:
             self.selected_gesture = key
             label.setStyleSheet(predefined_hover_label_style)
         else:
-            label.setStyleSheet(predefined_label_style)
+            label.setStyleSheet(predefined_label_style + noborder)
             self.selected_gesture = None
         
     def delete(self):

--- a/UI/Resources/Stylesheets/styles.py
+++ b/UI/Resources/Stylesheets/styles.py
@@ -209,3 +209,8 @@ camera_combo_style = '''
             width: 0px;
         }
 '''
+
+noborder='''
+            border: none;
+            background: transparent;
+'''


### PR DESCRIPTION
A javítás után a kamerabeállításoknál nem fekete a szöveg, valamint nem jelennek meg kívánatlan keretek a gombok körül. Javítva lett továbbá a kamerabállításokban a gomb színe a piros hover színre.